### PR TITLE
fix typo in the intro

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -157,7 +157,7 @@ Okay, let's create a new note. In this case we'll want to include a named parame
 when acting on the link.
 
 ```bash
-$ coreapi action add_note --params description="Email venue about conference dates"
+$ coreapi action add_note --param description="Email venue about conference dates"
 <Notes "http://notes.coreapi.org/">
     notes: [
         <Note "http://notes.coreapi.org/e7785f34-2b74-41d2-ab3f-f754f688987c/">
@@ -172,7 +172,7 @@ $ coreapi action add_note --params description="Email venue about conference dat
 Finally we'll update the state of the note we've just created:
 
 ```bash
-$ coreapi action notes 0 edit --params complete=true
+$ coreapi action notes 0 edit --param complete=true
 <Notes "http://notes.coreapi.org/">
     notes: [
         <Note "http://notes.coreapi.org/e7785f34-2b74-41d2-ab3f-f754f688987c/">


### PR DESCRIPTION
I got an error following the cli client intro, and realized it was just a minor typo.